### PR TITLE
feat: implement direct paste instead of text streaming (#3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,11 +25,11 @@ This is a minimal single-file Python application (`whisper_dictation.py`) that i
 1. **Audio Recording**: Uses PipeWire's `pw-record` to capture 16kHz mono audio to `/tmp/whisper_recording.wav`
 2. **Process Management**: Tracks recording process via PID file at `/tmp/whisper_dictation.pid`
 3. **Transcription**: Uses OpenAI's faster-whisper library with the "tiny" model for speed
-4. **Text Output**: Types transcribed text using `ydotool` (works on both X11/Wayland)
+4. **Text Output**: Copies transcribed text to clipboard using `wl-copy` and pastes using `ydotool key ctrl+v` (Wayland only)
 
 The application has two main functions:
 - `begin_recording()` - Spawns pw-record subprocess and saves PID
-- `end_recording()` - Kills recording process, transcribes audio, types result, cleans up
+- `end_recording()` - Kills recording process, transcribes audio, pastes result, cleans up
 
 ## Development Environment
 
@@ -44,7 +44,8 @@ Pre-commit hooks are automatically installed and use the `just` commands for con
 
 Runtime:
 - PipeWire (pw-record command)
-- ydotool daemon for text typing
+- wl-clipboard (wl-copy command for clipboard operations)
+- ydotool daemon for paste simulation
 - faster-whisper Python package
 
 The application includes comprehensive error handling for ydotool daemon connectivity issues and provides fallback instructions for manual clipboard usage.

--- a/README.md
+++ b/README.md
@@ -6,15 +6,17 @@ A minimal voice dictation tool using OpenAI's Whisper for Linux. Press a hotkey 
 
 - 🎤 Simple voice recording with PipeWire
 - 🤖 Accurate transcription using OpenAI's Whisper (via faster-whisper)
-- ⌨️ Automatic text typing with ydotool (works on X11/Wayland)
+- ⌨️ Instant text pasting using clipboard + ydotool (Wayland only)
 - 🚀 Minimal, single-file implementation
 - 🐧 NixOS-ready with included flake
 
 ## Requirements
 
 - Python 3.11+
+- Wayland compositor (required for wl-clipboard)
 - PipeWire (for audio recording)
-- ydotool (for typing text)
+- wl-clipboard (for clipboard operations)
+- ydotool (for paste simulation)
 - faster-whisper (Python package)
 
 ## Installation
@@ -32,21 +34,6 @@ nix develop
 # The script is ready to use!
 ```
 
-### Manual installation
-
-```bash
-# Install system dependencies
-# On Arch: sudo pacman -S pipewire ydotool
-# On Ubuntu: sudo apt install pipewire ydotool
-# On Fedora: sudo dnf install pipewire ydotool
-
-# Clone and setup
-git clone https://github.com/ananjiani/whisper-dictation.git
-cd whisper-dictation
-
-# Install Python dependency
-pip install faster-whisper
-```
 
 ## Usage
 
@@ -61,7 +48,7 @@ pip install faster-whisper
 ## How it works
 
 1. `begin` starts a `pw-record` process to record audio to a temporary WAV file
-2. `end` stops the recording, transcribes the audio using faster-whisper (tiny model), and types the result using ydotool
+2. `end` stops the recording, transcribes the audio using faster-whisper (tiny model), copies text to clipboard, and pastes it using ydotool
 3. Temporary files are cleaned up automatically
 
 ## Configuration

--- a/whisper_dictation.py
+++ b/whisper_dictation.py
@@ -84,11 +84,16 @@ def end_recording():
             else:
                 print(f"Transcription: {transcription}")
 
-                # Type the transcription using ydotool
-                print("Typing transcription...")
+                # Paste the transcription using clipboard + ydotool
+                print("Pasting transcription...")
                 try:
+                    # Copy to clipboard
                     subprocess.run(
-                        ["ydotool", "type", transcription],
+                        ["wl-copy"], input=transcription, text=True, check=True
+                    )
+                    # Simulate Ctrl+V paste
+                    subprocess.run(
+                        ["ydotool", "key", "ctrl+v"],
                         check=True,
                         capture_output=True,
                         text=True,
@@ -96,12 +101,21 @@ def end_recording():
                     print("Done!")
                 except subprocess.CalledProcessError as e:
                     error_msg = e.stderr if e.stderr else str(e)
-                    if (
+                    if "wl-copy" in str(e.cmd):
+                        print("⚠️  Could not copy to clipboard using wl-copy")
+                        print("Possible solutions:")
+                        print("1. Check if you're running in a Wayland session:")
+                        print("   echo $XDG_SESSION_TYPE")
+                        print("2. If on X11, try using xclip instead:")
+                        print("   echo '<transcription>' | xclip -selection clipboard")
+                        print("📋 Your transcription (ready to copy manually):")
+                        print(f"{transcription}")
+                    elif (
                         "ydotoold" in error_msg
                         or "socket" in error_msg
                         or "Connection refused" in error_msg
                     ):
-                        print("⚠️  Could not connect to ydotool daemon")
+                        print("⚠️  Could not connect to ydotool daemon for pasting")
 
                         # Check if user is in ydotool group
                         import grp
@@ -128,12 +142,13 @@ def end_recording():
                         print("   # Then logout and login again")
                         print("3. Try running ydotoold in user mode:")
                         print("   systemctl --user start ydotoold")
-                        print("4. Or use wl-clipboard (Wayland) / xclip (X11) instead:")
-                        print("   echo '<transcription>' | wl-copy")
-                        print("📋 Your transcription (ready to paste):")
+                        print(
+                            "4. Text is already in clipboard, manually press Ctrl+V to paste"
+                        )
+                        print("📋 Your transcription is in clipboard:")
                         print(f"{transcription}")
                     else:
-                        print(f"Error running ydotool: {error_msg}")
+                        print(f"Error during paste operation: {error_msg}")
                         print(f"📋 Transcription: {transcription}")
 
         except Exception as e:


### PR DESCRIPTION
## Summary
- Replace character-by-character typing with instant clipboard paste
- Use `wl-copy` + `ydotool key ctrl+v` instead of `ydotool type`
- Update error handling for clipboard operations
- Update documentation to reflect Wayland-only requirement

## Changes
- **whisper_dictation.py**: Replace streaming text output with clipboard + paste approach
- **README.md**: Update features and requirements to reflect direct paste and Wayland requirement
- **CLAUDE.md**: Update architecture documentation

## Test plan
- [x] Manual testing confirms direct paste works correctly
- [x] Error handling provides appropriate fallback messages
- [x] Documentation accurately reflects new behavior

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)