### PR TITLE
feat: simplify to stdout output for flexible piping (#3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This project uses `just` as a command runner. Run `just` to see all available co
 
 For testing the actual dictation workflow:
 - `./whisper_dictation.py begin` - Start audio recording
-- `./whisper_dictation.py end` - Stop recording, transcribe, and type result
+- `./whisper_dictation.py end` - Stop recording, transcribe, and output to stdout
 
 ## Code Architecture
 
@@ -25,11 +25,11 @@ This is a minimal single-file Python application (`whisper_dictation.py`) that i
 1. **Audio Recording**: Uses PipeWire's `pw-record` to capture 16kHz mono audio to `/tmp/whisper_recording.wav`
 2. **Process Management**: Tracks recording process via PID file at `/tmp/whisper_dictation.pid`
 3. **Transcription**: Uses OpenAI's faster-whisper library with the "tiny" model for speed
-4. **Text Output**: Copies transcribed text to clipboard using `wl-copy` and pastes using `ydotool key ctrl+v` (Wayland only)
+4. **Text Output**: Outputs transcribed text to stdout for flexible piping and processing
 
 The application has two main functions:
 - `begin_recording()` - Spawns pw-record subprocess and saves PID
-- `end_recording()` - Kills recording process, transcribes audio, pastes result, cleans up
+- `end_recording()` - Kills recording process, transcribes audio, outputs to stdout, cleans up
 
 ## Development Environment
 
@@ -43,9 +43,7 @@ Pre-commit hooks are automatically installed and use the `just` commands for con
 ## Dependencies
 
 Runtime:
-- PipeWire (pw-record command)
-- wl-clipboard (wl-copy command for clipboard operations)
-- ydotool daemon for paste simulation
-- faster-whisper Python package
+- PipeWire (pw-record command for audio recording)
+- faster-whisper Python package (for AI transcription)
 
-The application includes comprehensive error handling for ydotool daemon connectivity issues and provides fallback instructions for manual clipboard usage.
+The application outputs transcribed text to stdout, allowing users to pipe the output to clipboard tools, files, or custom processing scripts as needed.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,19 @@
 # whisper-dictation
 
-A minimal voice dictation tool using OpenAI's Whisper for Linux. Press a hotkey to start recording, speak, then press another hotkey to transcribe and type the text automatically.
+A minimal voice dictation tool using OpenAI's Whisper for Linux. Record audio, transcribe it using AI, and output the text to stdout for flexible piping and processing.
 
 ## Features
 
 - 🎤 Simple voice recording with PipeWire
 - 🤖 Accurate transcription using OpenAI's Whisper (via faster-whisper)
-- ⌨️ Instant text pasting using clipboard + ydotool (Wayland only)
+- 📤 Outputs transcription to stdout for flexible piping
 - 🚀 Minimal, single-file implementation
 - 🐧 NixOS-ready with included flake
 
 ## Requirements
 
 - Python 3.11+
-- Wayland compositor (required for wl-clipboard)
 - PipeWire (for audio recording)
-- wl-clipboard (for clipboard operations)
-- ydotool (for paste simulation)
 - faster-whisper (Python package)
 
 ## Installation
@@ -37,18 +34,34 @@ nix develop
 
 ## Usage
 
+### Basic transcription
 ```bash
 # Start recording
 ./whisper_dictation.py begin
 
-# Stop recording and type the transcribed text
+# Stop recording and output transcription to stdout
 ./whisper_dictation.py end
+```
+
+### Piping examples
+```bash
+# Copy to clipboard (Wayland)
+./whisper_dictation.py end | wl-copy
+
+# Copy to clipboard (X11)
+./whisper_dictation.py end | xclip -selection clipboard
+
+# Save to file
+./whisper_dictation.py end > transcription.txt
+
+# Process with custom script
+./whisper_dictation.py end | your-custom-processor
 ```
 
 ## How it works
 
 1. `begin` starts a `pw-record` process to record audio to a temporary WAV file
-2. `end` stops the recording, transcribes the audio using faster-whisper (tiny model), copies text to clipboard, and pastes it using ydotool
+2. `end` stops the recording, transcribes the audio using faster-whisper (tiny model), and outputs the text to stdout
 3. Temporary files are cleaned up automatically
 
 ## Configuration
@@ -60,18 +73,16 @@ Currently uses sensible defaults:
 
 ## Troubleshooting
 
-### ydotool not working
-
-Make sure ydotool daemon is running:
+### No audio recording
+Make sure PipeWire is running:
 ```bash
-sudo systemctl start ydotoold
-# or
-ydotoold &
+systemctl --user status pipewire
 ```
 
-You may need to be in the `input` group:
+### Transcription not working
+Check if faster-whisper is properly installed:
 ```bash
-sudo usermod -a -G input $USER
+python -c "from faster_whisper import WhisperModel; print('OK')"
 ```
 
 ## License


### PR DESCRIPTION
## Summary
Replace complex clipboard + paste functionality with simple stdout output for maximum flexibility and Unix-style piping.

## Key Improvements
- ✅ **Simplified**: Removed 60+ lines of complex paste/clipboard logic  
- ✅ **Universal**: Works on any system (Wayland, X11, headless) - no desktop dependencies
- ✅ **Flexible**: Users can pipe output anywhere: `./whisper_dictation.py end  < /dev/null |  wl-copy`
- ✅ **Unix Philosophy**: Do one thing well - just output transcribed text
- ✅ **Reliable**: No complex error handling for clipboard/paste tools

## Changes
- **whisper_dictation.py**: Replace clipboard+paste logic with simple `print(transcription)`
- **README.md**: Add piping examples, remove Wayland-only requirements
- **CLAUDE.md**: Update architecture docs, remove paste dependencies
- **Status messages**: Now go to stderr to avoid interfering with piped output

## Usage Examples
```bash
# Copy to clipboard (Wayland)
./whisper_dictation.py end | wl-copy

# Copy to clipboard (X11) 
./whisper_dictation.py end | xclip -selection clipboard

# Save to file
./whisper_dictation.py end > transcription.txt

# Process with custom script
./whisper_dictation.py end | your-custom-processor
```

## Test plan
- [x] Script runs without syntax errors
- [x] Linter passes
- [x] Documentation updated with new approach
- [x] Much simpler, more maintainable code

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)